### PR TITLE
✨ Add Genrocket type to common

### DIFF
--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -8,3 +8,7 @@ export * from "./middlewares/current-user";
 export * from "./middlewares/error-handler";
 export * from "./middlewares/validate-authorization";
 export * from "./middlewares/validate-request";
+
+export * from "./models/integrations/basic_integration";
+export * from "./models/integrations/genrocket";
+export * from "./models/integrations/integration";

--- a/common/src/models/integrations/basic_integration.ts
+++ b/common/src/models/integrations/basic_integration.ts
@@ -1,0 +1,5 @@
+export interface BasicIntegration {
+  title: string;
+  description: string;
+  logo: string;
+}

--- a/common/src/models/integrations/genrocket.ts
+++ b/common/src/models/integrations/genrocket.ts
@@ -1,0 +1,17 @@
+import { BasicIntegration } from "./basic_integration";
+
+type Step = {
+  desc: string;
+  image: string;
+};
+
+export interface IGenrocket extends BasicIntegration {
+  prerequisites: { desc: string; list: string[] };
+  connect: Step[];
+  linkDomain: { desc: string; steps: Step[] };
+  uploadAtts: { desc: string; alert: string; steps: Step[] };
+  getAtts: { desc: string; steps: Step[]; note: string };
+  unlink: { steps: Step[]; note: string };
+  unlinkProject: Step[];
+  knownIssues: { step: Step; note: string };
+}

--- a/common/src/models/integrations/integration.ts
+++ b/common/src/models/integrations/integration.ts
@@ -1,0 +1,4 @@
+import { IGenrocket } from "./genrocket";
+
+// Add all new integrations as value of Integration
+export type Integration = IGenrocket;


### PR DESCRIPTION
Move Genrocket type and Integration types to Common so they can be implemented in Service and the Client

Actually, this is just a paste implementation from backend/features/src models & entities. I'll update the implementation on the service once this changes are published in the **@atptalos/common** module